### PR TITLE
Added "skip" parameter to mojos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
                     <docker.host>${docker.host}</docker.host>
                     <docker.port>${docker.port}</docker.port>
                     <docker.provider>${docker.provider}</docker.provider>
+                    <skipTests>${skipTests}</skipTests>
                   </properties>
                 </configuration>
               </execution>

--- a/src/it/simple-it/pom.xml
+++ b/src/it/simple-it/pom.xml
@@ -62,6 +62,7 @@
               <goal>build-images</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <images>
                 <image>
                   <id>nginx</id>
@@ -77,6 +78,7 @@
           <execution>
             <id>start</id>
             <configuration>
+              <skip>${skipTests}</skip>
               <containers>
                 <container>
                   <id>Debian</id>
@@ -98,6 +100,9 @@
           </execution>
           <execution>
             <id>stop</id>
+            <configuration>
+              <skip>${skipTests}</skip>
+            </configuration>
             <goals>
               <goal>stop-containers</goal>
             </goals>

--- a/src/main/java/net/wouterdanes/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/net/wouterdanes/docker/maven/AbstractDockerMojo.java
@@ -28,12 +28,24 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     @Parameter(defaultValue = "remote", property = "docker.provider", required = true)
     private String providerName;
 
+    @Parameter(defaultValue = "false", property = "docker.skip", required = false)
+    private boolean skip;
+
     public void setProviderName(final String providerName) {
         this.providerName = providerName;
     }
 
+    public void setSkip(final boolean skip) {
+        this.skip = skip;
+    }
+
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
+    	if (skip) {
+            getLog().info("Execution skipped");
+            return;
+    	}
+
         getLog().info("Using docker provider: " + providerName);
         doExecute();
     }

--- a/src/test/java/net/wouterdanes/docker/maven/StartContainerMojoTest.java
+++ b/src/test/java/net/wouterdanes/docker/maven/StartContainerMojoTest.java
@@ -19,6 +19,7 @@ import net.wouterdanes.docker.provider.model.ExposedPort;
 import net.wouterdanes.docker.provider.model.ImageBuildConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,6 +88,17 @@ public class StartContainerMojoTest {
 
         ContainerStartConfiguration passedValue = captor.getValue();
         assertEquals("the-image-id", passedValue.getImage());
+    }
+
+    @Test
+    public void testThatMojoDoesNotStartWhenSkipped() throws Exception {
+        ContainerStartConfiguration startConfiguration = new ContainerStartConfiguration();
+        StartContainerMojo mojo = createMojo(startConfiguration);
+        mojo.setSkip(true);
+
+        mojo.execute();
+
+        verify(FakeDockerProvider.instance, never()).startContainer(startConfiguration);
     }
 
     private StartContainerMojo createMojo(final ContainerStartConfiguration startConfiguration) {


### PR DESCRIPTION
Because they take so long, I frequently need to skip integration tests
during my more frequent local builds. Given that this plugin is
primarily targeting the IT use case, it probably makes sense for these
executions o be similarly disabled.

Added "skip" to base mojos. Chose "skip", rather than enable/disable, to
correspond to skip parameters used to control surefire and failsafe
plugins.

Testing:
- Basic unit test added to StartContainerMojoTest
- Wired poms to leverage skipTests property to enab;e/disable docker
  executions in the IT pom. Then ran regular maven install with mvn
  install -P run-its -DskipTests=true
