### PR TITLE
The plugin now requires at least maven 3.1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
     <version>7</version>
   </parent>
 
+  <prerequisites>
+    <maven>3.1.1</maven>
+  </prerequisites>
+
   <groupId>net.wouterdanes.docker</groupId>
   <artifactId>docker-maven-plugin</artifactId>
   <version>1.6-SNAPSHOT</version>
@@ -73,8 +77,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <docker.host />
-    <docker.port />
+    <docker.host/>
+    <docker.port/>
   </properties>
 
   <dependencies>
@@ -210,6 +214,25 @@
               <target>${maven.compiler.target}</target>
               <encoding>${project.build.sourceEncoding}</encoding>
             </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.3.1</version>
+            <executions>
+              <execution>
+                <id>enforce-maven-version</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireMavenVersion>
+                      <version>3.1.1</version>
+                    </requireMavenVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/src/it/push-with-creds-it/pom.xml
+++ b/src/it/push-with-creds-it/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>net.wouterdanes.docker.it</groupId>
@@ -55,13 +55,13 @@
         <groupId>@project.groupId@</groupId>
         <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
-	    <configuration>
-	      <!-- Currently skipped owing to requirements for build environment to define sensitive property values e.g. docker.password -->
-	      <skip>true</skip>
-		  <userName>@docker.userName@</userName>
-		  <email>@docker.email@</email>
-		  <password>@docker.password@</password>
-	    </configuration>
+        <configuration>
+          <!-- Currently skipped owing to requirements for build environment to define sensitive property values e.g. docker.password -->
+          <skip>true</skip>
+          <userName>@docker.userName@</userName>
+          <email>@docker.email@</email>
+          <password>@docker.password@</password>
+        </configuration>
         <executions>
           <execution>
             <id>build</id>
@@ -139,6 +139,25 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/it/push-with-explicit-registry-it/pom.xml
+++ b/src/it/push-with-explicit-registry-it/pom.xml
@@ -74,6 +74,25 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/simple-it/pom.xml
+++ b/src/it/simple-it/pom.xml
@@ -128,6 +128,25 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/skip-docker-it/pom.xml
+++ b/src/it/skip-docker-it/pom.xml
@@ -131,6 +131,25 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/skip-using-property-it/pom.xml
+++ b/src/it/skip-using-property-it/pom.xml
@@ -127,6 +127,25 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/tag-and-push-it/pom.xml
+++ b/src/it/tag-and-push-it/pom.xml
@@ -92,6 +92,25 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Also added the enforcer plugin to the ITs and main pom.xml to ensure maven 3.1.1+
Fixes #19 
