### PR TITLE
Pattern match correctly image names with "." and/or "-"

### DIFF
--- a/src/main/java/net/wouterdanes/docker/remoteapi/model/ImageDescriptor.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/model/ImageDescriptor.java
@@ -31,7 +31,8 @@ public class ImageDescriptor {
 
     private static final Pattern IMAGE_QUALIFIER = Pattern.compile("^"
             + "((?<registry>[\\w\\.\\-]+(:\\d+)?)/)??" // registry
-            + "((?<repository>[\\w]+)/)?(?<image>[\\w]+)" // repository/image
+            + "((?<repository>[\\w]+)/)?" // repository
+            + "(?<image>[\\w\\.\\-]+)" // image
             + "(:(?<tag>[\\w\\.\\-]+))?" // tag
             + "$");
 

--- a/src/test/java/net/wouterdanes/docker/remoteapi/ImageDescriptorTest.java
+++ b/src/test/java/net/wouterdanes/docker/remoteapi/ImageDescriptorTest.java
@@ -64,13 +64,20 @@ public class ImageDescriptorTest {
                 "index_01-reg.tutum.co:5000/wouter/ubuntu:precise", "index_01-reg.tutum.co:5000", "wouter", "ubuntu", "precise",
                 "index_01-reg.tutum.co:5000/wouter/ubuntu",  "wouter/ubuntu", "wouter/ubuntu:precise");
 
+        // check for image names with "." and "-"
+        assertDescriptor("localhost:5000/library/ubuntu-precise", "localhost:5000/library/ubuntu-precise",
+                "localhost:5000", "library", "ubuntu-precise", null, "localhost:5000/library/ubuntu-precise",
+                "library/ubuntu-precise", "library/ubuntu-precise");
+        assertDescriptor("localhost:5000/library/ubuntu.precise", "localhost:5000/library/ubuntu.precise",
+                "localhost:5000", "library", "ubuntu.precise", null, "localhost:5000/library/ubuntu.precise",
+                "library/ubuntu.precise", "library/ubuntu.precise");
+
         // check for tags "." and "-" in them
         assertDescriptor("ubuntu:14.04", "ubuntu:14.04", null, null, "ubuntu", "14.04",
                 "ubuntu", "ubuntu", "ubuntu:14.04");
         assertDescriptor("ubuntu:mark-2", "ubuntu:mark-2", null, null, "ubuntu", "mark-2",
                 "ubuntu", "ubuntu", "ubuntu:mark-2");
     }
-
 
     private static void assertDescriptor(String qualifier,
             String id, String registry, String repository,


### PR DESCRIPTION
Docker allows image names to have dots "." and hyphens "-".

Current version of docker-maven-plugin creates wrongly formatted push request when the image name has dots or hyphens and a tag. In this case the tag is included in the middle of the url instead of being a query parameter.

This pull request modifies how image qualifier is matched, and accepts dots and hyphens in an image name. With this modification, tag is detected correctly and is put to "tag" query parameter in a push request.
