### PR TITLE
Modify pull image to work with private registry

### DIFF
--- a/src/main/java/net/wouterdanes/docker/remoteapi/ImagesService.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/ImagesService.java
@@ -43,19 +43,10 @@ public class ImagesService extends BaseService {
         WebTarget target = getServiceEndPoint()
                 .path("create");
 
-        if (descriptor.getRepository().isPresent()) {
-        	target = target.queryParam("fromImage", 
-        			String.format("%s/%s", descriptor.getRepository().get(), descriptor.getImage()));
-        } else {
-        	target = target.queryParam("fromImage", descriptor.getImage());
-        }
+        target = target.queryParam("fromImage", descriptor.getRegistryRepositoryAndImage());
 
         if (descriptor.getTag().isPresent()) {
             target = target.queryParam("tag", descriptor.getTag().get());
-        }
-
-        if (descriptor.getRegistry().isPresent()) {
-            target = target.queryParam("registry", descriptor.getRegistry().get());
         }
 
         return target.request()


### PR DESCRIPTION
Put image's name ([registry/][repository/]image) to fromImage query parameter. Remove repo and registry query parameters as those are not needed.

The plugin could not pull images from a private repository at start-containers goal when the image had a private registry name in it.

There are no tests included for this pull request but I successfully tested it against our private repository and Docker Hub Registry with different kinds of names.
