### PR TITLE
Improved the example for artifact usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,12 @@ Below is an example snippet.
                   <dockerFile>${project.basedir}/src/test/resources/Dockerfile</dockerFile>
                   <artifacts>
                     <artifact>
-                      <file>${project.basedir}/src/test/resources/httpd.conf</file>
-                      <dest>etc/httpd</dest>
+                      <file>${project.basedir}/src/test/resources/nginx.conf</file>
+                      <dest>etc/nginx/nginx.conf</dest>
+                    </artifact>
+                    <artifact>
+                      <file>${project.basedir}/src/test/resources/sites-available/</file>
+                      <dest>etc/nginx/sites-available/</dest>
                     </artifact>
                   </artifacts>
                   <keep>true</keep>


### PR DESCRIPTION
I think the current example is very confusing. It's not clear if the path in dest is a directory where the actual file will be placed or if it's the exact path of the file within the tar.

Furthermore, I added an example to show the "put the whole directory in the tar" feature which was something I missed so much in 2.1. I was very happy to find out in the code that it was possible now.
