### PR TITLE
Now use StopContainer instead of KillContainer.

### DIFF
--- a/src/main/java/net/wouterdanes/docker/provider/RemoteApiBasedDockerProvider.java
+++ b/src/main/java/net/wouterdanes/docker/provider/RemoteApiBasedDockerProvider.java
@@ -86,7 +86,7 @@ public abstract class RemoteApiBasedDockerProvider implements DockerProvider {
 
     @Override
     public void stopContainer(final String containerId) {
-        getContainersService().killContainer(containerId);
+        getContainersService().stopContainer(containerId);
     }
 
     @Override

--- a/src/main/java/net/wouterdanes/docker/remoteapi/ContainersService.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/ContainersService.java
@@ -73,10 +73,11 @@ public class ContainersService extends BaseService {
         checkContainerTargetingResponse(id, statusInfo);
     }
 
-    public void killContainer(String id) {
+    public void stopContainer(String id) {
         Response response = getServiceEndPoint()
                 .path(id)
-                .path("/kill")
+                .path("/stop")
+                .queryParam("t", 10)
                 .request()
                 .method(HttpMethod.POST);
 


### PR DESCRIPTION
This will allow for graceful shutdowns.

Currently this plugin does a kill during "stop" this means all processes inside the docker get SIGKILL.

Changed to "stop" with a 10 second timeout, this will send a SIGTERM to all processes, after 10 seconds it will send a SIGKILL to all processes still running, this gives us time for graceful cleanups, especially in integration tests it means we can flush our logs out of the system.