### PR TITLE
Add shutdown hook to avoid dangling containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ pom.xml here: [pom.xml](https://github.com/wouterd/docker-maven-plugin/blob/mast
             <goal>start-containers</goal>
           </goals>
           <configuration>
+            <!-- You can set forceCleanup to true to stop and remove started containers
+                 at the end of the build even if the stop-containers goal is not executed
+                 (useful for preventing Ctrl+C causing dangling containers) -->
+            <forceCleanup>false</forceCleanup>
             <containers>
               <container>
                 <id>mongo</id>

--- a/src/main/java/net/wouterdanes/docker/maven/StopContainerMojo.java
+++ b/src/main/java/net/wouterdanes/docker/maven/StopContainerMojo.java
@@ -34,24 +34,8 @@ public class StopContainerMojo extends AbstractPreVerifyDockerMojo {
 
     @Override
     public void doExecute() throws MojoExecutionException, MojoFailureException {
-        for (StartedContainerInfo container : getStartedContainers()) {
-            String containerId = container.getContainerInfo().getId();
-            getLog().info(String.format("Stopping container '%s'..", containerId));
-            try {
-                getDockerProvider().stopContainer(containerId);
-            } catch (DockerException e) {
-                getLog().error("Failed to stop container", e);
-            }
-        }
-        for (StartedContainerInfo container : getStartedContainers()) {
-            String containerId = container.getContainerInfo().getId();
-            getLog().info(String.format("Deleting container '%s'..", containerId));
-            try {
-                getDockerProvider().deleteContainer(containerId);
-            } catch (DockerException e) {
-                getLog().error("Failed to delete container", e);
-            }
-        }
+        cleanUpStartedContainers();
+
         for (BuiltImageInfo image : getBuiltImages()) {
             if (image.shouldKeepAfterStopping()) {
                 getLog().info(String.format("Keeping image %s", image.getImageId()));


### PR DESCRIPTION
This cleanup defaults to off to support workflows based on several
maven executions (e.g. 1 execution to start containers, 1 to
run tests, and 1 to stop all the started containers).

Fixes #81.