### PR TITLE
[Fixes #85] Adding logs parameter for stop-containers

### DIFF
--- a/src/it/container-logs-it/pom.xml
+++ b/src/it/container-logs-it/pom.xml
@@ -1,0 +1,258 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.wouterdanes</groupId>
+    <artifactId>container-logs-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>container-logs-it</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- for the HTTP connector / request handling -->
+        <dependency>
+            <groupId>io.ratpack</groupId>
+            <artifactId>ratpack-core</artifactId>
+            <version>0.9.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.ratpack</groupId>
+            <artifactId>ratpack-guice</artifactId>
+            <version>0.9.7</version>
+        </dependency>
+
+        <!-- for MongoDB connection stuff -->
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.7</version>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.3.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>0.7-groovy-2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>2.9.0-01</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>2.3.4-01</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4.1</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>ratpack.launch.RatpackMain</mainClass>
+                        </manifest>
+                    </archive>
+                    <finalName>discuss</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Integration testing -->
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <systemProperties>
+                        <app.base.1>http://${docker.containers.app.ports.8080/tcp.host}:${docker.containers.app.ports.8080/tcp.port}</app.base.1>
+                        <app.base.2>http://${docker.containers.app2.ports.8080/tcp.host}:${docker.containers.app2.ports.8080/tcp.port}</app.base.2>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>package</id>
+                        <goals>
+                            <goal>build-images</goal>
+                        </goals>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <id>app</id>
+	                                <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                                    <artifacts>
+	                                    <artifact>
+                                            <file>${project.build.directory}/discuss-jar-with-dependencies.jar</file>
+	                                    </artifact>
+                                    </artifacts>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>start</id>
+                        <goals>
+                            <goal>start-containers</goal>
+                        </goals>
+                        <configuration>
+                            <containers>
+                                <container>
+                                    <id>mongo</id>
+                                    <image>mongo:2.6</image>
+                                    <waitForStartup>waiting for connections on port 27017</waitForStartup>
+                                </container>
+                                <container>
+                                    <id>app</id>
+                                    <image>app</image>
+                                    <links>
+                                        <link>
+                                            <containerId>mongo</containerId>
+                                            <containerAlias>mongo</containerAlias>
+                                        </link>
+                                    </links>
+                                    <env>
+                                        <APP_MESSAGE>Hello, world!</APP_MESSAGE>
+                                    </env>
+                                    <waitForStartup>Ratpack started for</waitForStartup>
+                                </container>
+                                <container>
+                                    <id>app2</id>
+                                    <image>app</image>
+                                    <links>
+                                        <link>
+                                            <containerId>mongo</containerId>
+                                            <containerAlias>mongo</containerAlias>
+                                        </link>
+                                    </links>
+                                    <env>
+                                        <APP_MESSAGE>I am, so I message</APP_MESSAGE>
+                                    </env>
+                                    <waitForStartup>Ratpack started for</waitForStartup>
+                                </container>
+                            </containers>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <goals>
+                            <goal>stop-containers</goal>
+                        </goals>
+                        <configuration>
+                            <logs>${project.build.directory}/logs</logs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>@maven.required.version@</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/src/it/container-logs-it/src/main/docker/Dockerfile
+++ b/src/it/container-logs-it/src/main/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM wouterd/java8
+
+ADD discuss-jar-with-dependencies.jar /discuss.jar
+
+ENTRYPOINT ["java", "-jar", "-Dmongo.host=mongo", "/discuss.jar"]
+
+EXPOSE 8080

--- a/src/it/container-logs-it/src/main/java/net/wouterdanes/Application.java
+++ b/src/it/container-logs-it/src/main/java/net/wouterdanes/Application.java
@@ -1,0 +1,93 @@
+package net.wouterdanes;
+
+import com.mongodb.*;
+import com.mongodb.util.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ratpack.guice.Guice;
+import ratpack.handling.ChainAction;
+import ratpack.handling.Handler;
+import ratpack.launch.HandlerFactory;
+import ratpack.launch.LaunchConfig;
+
+import java.util.Date;
+import java.util.stream.StreamSupport;
+
+/**
+ * Main entrypoint for this application
+ */
+public class Application implements HandlerFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+  private static final String ENV_APP_MESSAGE = "APP_MESSAGE";
+
+  @Override
+  public Handler create(final LaunchConfig launchConfig) throws Exception {
+    return Guice.handler(launchConfig, bindingsSpec -> {
+      String mongoHost = System.getProperty("mongo.host", "localhost");
+      log.info("Mongo host = {}", mongoHost);
+      DBCollection collection = new MongoClient(mongoHost)
+          .getDB("discuss")
+          .getCollection("posts");
+      bindingsSpec.bind(DBCollection.class, collection);
+    }, new Routes());
+  }
+
+  private class Routes extends ChainAction {
+
+    @Override
+    protected void execute() throws Exception {
+
+      get("message", ctx -> ctx.render(System.getenv(ENV_APP_MESSAGE)));
+
+      prefix("posts", (Handler) ctx -> ctx.byMethod(posts -> {
+            posts.post(context -> {
+
+              String body = context.getRequest().getBody().getText();
+
+              DBCollection collection = context.get(DBCollection.class);
+
+              DBObject object = new BasicDBObjectBuilder()
+                  .add("dateTime", new Date())
+                  .add("message", JSON.parse(body))
+                  .get();
+
+              collection.insert(object);
+
+              context.getResponse().status(201);
+              context.getResponse().send();
+
+            });
+
+            posts.get(context -> {
+
+              DBObject fieldSpec = new BasicDBObjectBuilder()
+                  .add("_id", 0)
+                  .add("dateTime", 1)
+                  .add("message", 1)
+                  .get();
+
+              DBCollection collection = context.get(DBCollection.class);
+              DBCursor cursor = collection.find(new BasicDBObject(), fieldSpec).sort(new BasicDBObject("dateTime", -1));
+
+              if (!cursor.hasNext()) {
+                context.clientError(404);
+                return;
+              }
+
+              String result = "[" +
+                  StreamSupport.stream(cursor.spliterator(), true)
+                      .map(JSON::serialize)
+                      .reduce((s, s2) -> s + "," + s2)
+                      .get()
+                  + "]";
+
+              context.getResponse().send("application/json", result);
+
+            });
+          }
+      ));
+
+    }
+  }
+}

--- a/src/it/container-logs-it/src/main/resources/log4j.xml
+++ b/src/it/container-logs-it/src/main/resources/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="true"
+                     xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+  <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss} %5p %c{1} - %m%n"/>
+    </layout>
+  </appender>
+
+  <root>
+    <level value="INFO"/>
+    <appender-ref ref="consoleAppender"/>
+  </root>
+
+</log4j:configuration>

--- a/src/it/container-logs-it/src/main/resources/ratpack.properties
+++ b/src/it/container-logs-it/src/main/resources/ratpack.properties
@@ -1,0 +1,2 @@
+handlerFactory=net.wouterdanes.Application
+port=8080

--- a/src/it/container-logs-it/src/test/java/net/wouterdanes/ApplicationIT.groovy
+++ b/src/it/container-logs-it/src/test/java/net/wouterdanes/ApplicationIT.groovy
@@ -1,0 +1,97 @@
+package net.wouterdanes
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.client.WebTarget
+import javax.ws.rs.core.MediaType
+
+import static javax.ws.rs.client.Entity.entity
+
+class ApplicationIT extends Specification {
+
+  static Logger log = LoggerFactory.getLogger(ApplicationIT)
+
+  WebTarget app1;
+  WebTarget app2;
+
+  void setup() {
+
+    def appBase1 = System.getProperty('app.base.1')
+    app1 = ClientBuilder.newClient().target(appBase1)
+
+    def appBase2 = System.getProperty('app.base.2')
+    app2 = ClientBuilder.newClient().target(appBase2)
+
+  }
+
+  def "Posts can be added"() {
+
+    when:
+    def message = new JsonBuilder([
+        body: 'TEST BODY'
+    ])
+    def response = app1.path('posts')
+        .request().buildPost(entity(message.toString(), MediaType.APPLICATION_JSON_TYPE))
+        .invoke()
+
+    then:
+    response.status == 201
+
+    cleanup:
+    response.close()
+
+  }
+
+  def "Posts can be looked up"() {
+
+    when:
+    def response = app1.path('posts').request(MediaType.APPLICATION_JSON_TYPE).get()
+
+    then:
+    response.status == 404 || response.status == 200
+
+    cleanup:
+    response.close()
+
+  }
+
+  def "The last post posted is the first post returned from another node"() {
+
+    when:
+    def messageBody = UUID.randomUUID().toString()
+
+    def message = new JsonBuilder([
+        body: messageBody
+    ]).toString()
+
+    def payload = entity(message, MediaType.APPLICATION_JSON_TYPE)
+
+    app1.path('posts').request().post(payload).close()
+
+    def response = app2.path('posts').request(MediaType.APPLICATION_JSON_TYPE).get()
+    def result = response.readEntity(String)
+
+    def json = new JsonSlurper().parseText(result)
+
+    then:
+    json[0].message.body == messageBody
+
+  }
+
+  def "The message service returns the APP_MESSAGE enviroment variable"() {
+
+    when:
+    def app1Response = app1.path('message').request().get(String)
+    def app2Response = app2.path('message').request().get(String)
+
+    then:
+    app1Response == 'Hello, world!'
+    app2Response == 'I am, so I message'
+
+  }
+}

--- a/src/it/container-logs-it/verify.groovy
+++ b/src/it/container-logs-it/verify.groovy
@@ -1,0 +1,3 @@
+
+def logfile = new File( basedir, "target/logs/app.log" )
+assert logfile.exists()


### PR DESCRIPTION
Allows build to save container logs to the specified directory, with the filename format <container-name>.log. Disabled by default (empty `logs` parameter).