### PR TITLE
Fix #96 - Remove the -q option when building a docker image.

### DIFF
--- a/src/main/java/net/wouterdanes/docker/remoteapi/MiscService.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/MiscService.java
@@ -109,7 +109,6 @@ public class MiscService extends BaseService {
     public String buildImage(byte[] tarArchive, Optional<String> name) {
         Response response = getServiceEndPoint()
                 .path("/build")
-                .queryParam("q", true)
                 .queryParam("t", name.orElse(null))
                 .queryParam("forcerm")
                 .request(MediaType.APPLICATION_JSON_TYPE)


### PR DESCRIPTION
This will enable the plugin to detect a successful build with docker-machine 0.6.0.

It does make the output a lot more verbose. It may be worth tweaking the logging in MiscService.java to stream out to debug rather than System.out.