### PR TITLE
Fix #87 - Add support for setting container mac address

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,18 @@ The hostname can be set by adding a <hostname> element to a container configurat
 
             <container>
                 <id>app</id>
-                <iamge>app</image>
+                <image>app</image>
                 <hostname>appserver1</hostname>
+            </container>
+
+## Setting the hostname
+
+The macAddress can be set by adding a <macAddress> element to a container configuration.
+
+            <container>
+                <id>app</id>
+                <image>app</image>
+                <macAddress>12:34:56:78:9a:bc</macAddress>
             </container>
 
 ## Linking containers

--- a/src/main/java/net/wouterdanes/docker/provider/RemoteApiBasedDockerProvider.java
+++ b/src/main/java/net/wouterdanes/docker/provider/RemoteApiBasedDockerProvider.java
@@ -176,7 +176,8 @@ public abstract class RemoteApiBasedDockerProvider implements DockerProvider {
         ContainerCreateRequest createRequest = new ContainerCreateRequest()
                 .fromImage(imageId)
                 .withEnv(configuration.getEnv())
-                .withHostname(configuration.getHostname());
+                .withHostname(configuration.getHostname())
+                .withMacAddress(configuration.getMacAddress());
 
         String containerId;
         try {

--- a/src/main/java/net/wouterdanes/docker/provider/model/ContainerStartConfiguration.java
+++ b/src/main/java/net/wouterdanes/docker/provider/model/ContainerStartConfiguration.java
@@ -54,6 +54,11 @@ public class ContainerStartConfiguration {
     private String hostname;
 
     /**
+     * Supply an optional mac address for the container
+     */
+    private String macAddress;
+
+    /**
      * Set the image name or id to use and returns the object so you can chain from/with statements.
      *
      * @param image the image name or id
@@ -100,6 +105,11 @@ public class ContainerStartConfiguration {
         this.hostname = hostname;
         return this;
     }
+
+    public ContainerStartConfiguration withMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+        return this;
+    }
     
     public String getImage() {
         return image;
@@ -119,6 +129,10 @@ public class ContainerStartConfiguration {
 
     public String getHostname() {
         return hostname;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
     }
     
     public String getWaitForStartup() {

--- a/src/main/java/net/wouterdanes/docker/remoteapi/ContainersService.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/ContainersService.java
@@ -44,15 +44,15 @@ public class ContainersService extends BaseService {
         super(dockerApiRoot, "/containers");
     }
 
-    public String createContainer(ContainerCreateRequest request) {
+    public String createContainer(ContainerCreateRequest containerCreateRequest) {
         String createResponseStr;
         try {
             createResponseStr = getServiceEndPoint()
                     .path("/create")
                     .request(MediaType.APPLICATION_JSON_TYPE)
-                    .post(Entity.entity(toJson(request), MediaType.APPLICATION_JSON_TYPE), String.class);
+                    .post(Entity.entity(toJson(containerCreateRequest), MediaType.APPLICATION_JSON_TYPE), String.class);
         } catch (WebApplicationException e) {
-            throw makeImageTargetingException(request.getImage(), e);
+            throw makeImageTargetingException(containerCreateRequest.getImage(), e);
         }
         ContainerCreateResponse createResponse = toObject(createResponseStr, ContainerCreateResponse.class);
         return createResponse.getId();

--- a/src/main/java/net/wouterdanes/docker/remoteapi/model/ContainerCreateRequest.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/model/ContainerCreateRequest.java
@@ -44,6 +44,8 @@ public class ContainerCreateRequest {
     private String image;
     @JsonProperty("Env")
     private List<String> env;
+    @JsonProperty("MacAddress")
+    private String macAddress;
     
     public String getHostname() {
         return hostname;
@@ -67,6 +69,10 @@ public class ContainerCreateRequest {
 
     public List<String> getEnv() {
         return env != null ? Collections.unmodifiableList(env) : Collections.<String>emptyList();
+    }
+
+    public String getMacAddress() {
+        return macAddress;
     }
 
     public ContainerCreateRequest withEnv(Map<String, String> env) {
@@ -101,6 +107,11 @@ public class ContainerCreateRequest {
 
     public ContainerCreateRequest withCommands(List<String> commands) {
         this.cmd = new ArrayList<>(commands);
+        return this;
+    }
+
+    public ContainerCreateRequest withMacAddress(String macAddress) {
+        this.macAddress = macAddress;
         return this;
     }
 

--- a/src/test/java/net/wouterdanes/docker/maven/StartContainerMojoTest.java
+++ b/src/test/java/net/wouterdanes/docker/maven/StartContainerMojoTest.java
@@ -345,6 +345,22 @@ public class StartContainerMojoTest {
         assertEquals("test-hostname", passedValue.getHostname());
     }
 
+    @Test
+    public void testThatConfiguredMacAddressGetsPassedToDocker() throws Exception {
+        ContainerStartConfiguration configuration = new ContainerStartConfiguration().withMacAddress("12:34:56:78:9a:bc");
+        StartContainerMojo mojo = createMojo(configuration);
+
+        mojo.execute();
+
+        ArgumentCaptor<ContainerStartConfiguration> captor = ArgumentCaptor.forClass(ContainerStartConfiguration.class);
+        verify(FakeDockerProvider.instance).startContainer(captor.capture());
+
+        assert mojo.getPluginErrors().isEmpty();
+
+        ContainerStartConfiguration passedValue = captor.getValue();
+        assertEquals("12:34:56:78:9a:bc", passedValue.getMacAddress());
+    }
+
     private StartContainerMojo createMojo(final ContainerStartConfiguration startConfiguration) {
         return createMojo(startConfiguration, FAKE_PROVIDER_KEY);
     }


### PR DESCRIPTION
This adds the ability to set a mac address for a container.

I see that you have a VerifyHostnameSetIT that is @ignored and doesn't work so I haven't tried to add something similar for macAddress.  Let me know if it's a problem.