### PR TITLE
Add some feedback when pulling images 

### DIFF
--- a/src/main/java/net/wouterdanes/docker/remoteapi/ImagesService.java
+++ b/src/main/java/net/wouterdanes/docker/remoteapi/ImagesService.java
@@ -72,12 +72,12 @@ public class ImagesService extends BaseService {
 
         InputStream inputStream = (InputStream) response.getEntity();
 
-        parseSteamToDisplayImageDownloadStatus(inputStream);
+        parseStreamToDisplayImageDownloadStatus(inputStream);
 
         return response.readEntity(String.class);
     }
 
-    private static void parseSteamToDisplayImageDownloadStatus(final InputStream inputStream) {
+    private static void parseStreamToDisplayImageDownloadStatus(final InputStream inputStream) {
         InputStreamReader isr = new InputStreamReader(inputStream);
         BufferedReader reader = new BufferedReader(isr);
 


### PR DESCRIPTION
This is a small tweak that adds some feedback to the user while images are being pulled so that it doesn't look like the plugin has hung.

The feedback is minimal, it just prints a . for every bit of the stream that comes down. 

It will show that the plugin hasn't hung whilst producing minimal output on the terminal.  I haven't bothered trying to do anything fancy like working out how long is left (those metrics are normally pretty worthless anyway).