### PR TITLE
Fix #34 Create a RunContainersMojo that allows you to use mvn docker:run

### DIFF
--- a/src/main/java/net/wouterdanes/docker/maven/RunContainersMojo.java
+++ b/src/main/java/net/wouterdanes/docker/maven/RunContainersMojo.java
@@ -1,0 +1,69 @@
+/*
+    Copyright 2014 Wouter Danes
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+package net.wouterdanes.docker.maven;
+
+import net.wouterdanes.docker.provider.model.ContainerStartConfiguration;
+import net.wouterdanes.docker.remoteapi.exception.DockerException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * This class is responsible for starting docking containers in the pre-integration phase of the maven build. The goal
+ * is called "start-containers"
+ */
+@Mojo(defaultPhase = LifecyclePhase.INTEGRATION_TEST, name = "run", threadSafe = true, requiresDirectInvocation = true)
+public class RunContainersMojo extends StartContainerMojo {
+
+    private static final int SLEEP = 500;
+
+    @Inject
+    public RunContainersMojo(List<ContainerStartConfiguration> containers) {
+        super(containers);
+    }
+
+    @Override
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
+        Runtime.getRuntime().addShutdownHook(new Thread(this::cleanUpStartedContainers));
+
+        super.doExecute();
+
+        getLog().info("Press Ctrl-C to stop the container...");
+        waitForUserInteraction();
+    }
+
+    private void waitForUserInteraction() {
+        while (true) {
+            try {
+                Thread.sleep(SLEEP);
+            } catch (InterruptedException e) {
+                throw new DockerException("Aborting container wait.", e);
+            }
+        }
+    }
+
+    @Override
+    protected String getMojoGoalName() {
+        return "run";
+    }
+}


### PR DESCRIPTION
This is a very basic implementation as it stands.

Right now you have a few options:

- `mvn docker:run` - Start up the containers
- `mvn docker:build-images docker:run` - Build missing images and start up the containers
- `mvn package docker:run` - Rebuild the images and start up the containers

You could start trying to force the docker:run goal to build images as well as running them, but then you'll be duplicating parts of the build images MOJO for the config and you'll have to extract the functions it uses out into a separate class (Unless there is some Maven magic that allows you to force the run of multiple goals inside a MOJO I don't know about at the moment).

Once the containers have started the code drops into an infinite loop until CTRL + C has been pressed.  You could start adding state to the containers and check that they are still in a running state instead of just having an infinite loop, or you could continually query the remote API to see if they are still up and running, but that's a bit more work (And I don't think it's really going to add much additional benefit).